### PR TITLE
Change Dependabot schedule from daily to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,4 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "monthly"


### PR DESCRIPTION
Since this project is less actively developed/deployed than some of our others, so dependency update PRs are more of a distraction compared to those on which we're working on on a daily basis anyway.

In addition, the new GitHub auto-merge functionality combined with Dependabot's automatic rebasing, makes conflicting PRs less annoying to deal with, so spacing out the PRs by using the daily schedule is no longer necessary.