### PR TITLE
Reduce team review request noise from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,7 @@
+# Default to requesting reviews from the Languages team.
 * @heroku/languages
+
+# However, request review from specific owners instead for files that are
+# updated by Dependabot, to reduce team review request noise.
+package.json @Malax
+yarn.lock @Malax


### PR DESCRIPTION
For the same reasons as:
https://github.com/heroku/webapp-runner/pull/423

I'd not updated this repo previously, since I'd thought it was going to be sunset soon. However, those plans have been delayed.