### PR TITLE
Fix CI after Heroku-24 default stack change

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -68,7 +68,7 @@ yarn test
 
 heroku plugins:link .
 
-app="heroku-exec-test-$(openssl rand -hex 4)"
+app="plugin-java-test-$(openssl rand -hex 4)"
 echo "Preparing test app ${app}..."
 
 mkdir -p tmp
@@ -80,8 +80,7 @@ cd ${app}
 echo "Creating git repo..."
 git init
 
-echo "web: python3 -m http.server \$PORT" > Procfile
-echo "worker: echo 'class A{public static void main(String[] a) throws Exception{while(true){Thread.sleep(1000);}}}' > A.java; javac A.java; java A" >> Procfile
+echo "worker: echo 'class A{public static void main(String[] a) throws Exception{while(true){Thread.sleep(1000);}}}' > A.java; javac A.java; java A" > Procfile
 
 echo "Creating Heroku app..."
 heroku create ${app}
@@ -97,22 +96,6 @@ trap "{ echo ''; echo 'Cleaning up...'; heroku destroy ${app} --confirm ${app}; 
 echo "Deploying..."
 git push heroku master
 
-git commit -m "redeploy" --allow-empty
-git push heroku master
-
-echo -n "Waiting for dyno..."
-state="starting"
-while [ "up" != "$state" ]; do
-  if [ "starting" != "$state" ]; then
-    echo "WARNING: dyno state is \"${state}\""
-  fi
-  echo -n "."
-  sleep 2
-  state=$(heroku ps --json | jq .[0].state -r)
-done
-echo ""
-
-heroku ps:scale web=0
 heroku ps:scale worker=1
 
 dyno="worker.1"


### PR DESCRIPTION
After the change in default stack to Heroku-24, tests were failing with:

```
.WARNING: dyno state is "crashed"
```

eg:
https://github.com/heroku/plugin-java/actions/runs/11929587658/job/33248666510#step:9:218

This is due to the test app having a `web` process that uses Python, when the test app doesn't configure the Python buildpack.

It turns out the test app doesn't even need the web process or Python - it appears to be a copy-paste leftover from the heroku-exec tests (on which these tests were based).

As such, I've removed the unused parts of the test, which also fixes the failures on Heroku-24.