### PR TITLE
Fix GUSINFO metadata in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # Default to requesting reviews from the Languages team.
 #ECCN:Open Source
-#GUSINFO:Languages,Heroku JVM Platform
+#GUSINFO:Heroku - Languages,Heroku JVM Platform
 * @heroku/languages
 
 # However, request review from specific owners instead for files that are


### PR DESCRIPTION
Since the Languages team was renamed to `Heroku - Languages` in GUS some time ago.

GUS-W-21708465.
